### PR TITLE
Add child ratio overload

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Thumbs.db
 *.bak
 *.log
 logs
+package-lock.json
 
 *.common-js.js
 *.es-modules.js

--- a/dist/intrinsic-scale.browser.js
+++ b/dist/intrinsic-scale.browser.js
@@ -1,2 +1,2 @@
 /*! npm.im/intrinsic-scale */
-!function(i){"use strict";function n(i){return function(n,t,c,r){var e,s,u=c/r,a=n/t;return(i?u>a:u<a)?(e=n,s=e/u):(s=t,e=s*u),{width:e,height:s,x:(n-e)/2,y:(t-s)/2}}}var t=n(!0),c=n(!1);i.contain=t,i.cover=c}(this.intrinsicScale=this.intrinsicScale||{});
+!function(i){"use strict";function n(i){return function(n,t,c,r){var e=c/r,s=n/t,u=n,a=t;return(i?e>s:e<s)?a=u/e:u=a*e,{width:u,height:a,x:(n-u)/2,y:(t-a)/2}}}var t=n(!0),c=n(!1);i.contain=t,i.cover=c}(this.intrinsicScale=this.intrinsicScale||{});

--- a/dist/intrinsic-scale.browser.js
+++ b/dist/intrinsic-scale.browser.js
@@ -1,2 +1,2 @@
 /*! npm.im/intrinsic-scale */
-!function(i){"use strict";function n(i){return function(n,t,c,r){var e=c/r,s=n/t,u=n,a=t;return(i?e>s:e<s)?a=u/e:u=a*e,{width:u,height:a,x:(n-u)/2,y:(t-a)/2}}}var t=n(!0),c=n(!1);i.contain=t,i.cover=c}(this.intrinsicScale=this.intrinsicScale||{});
+!function(i){"use strict";function n(i){return function(n,t,r,c){var e="number"==typeof c?r/c:r,u=n/t,o=n,s=t;return(i?e>u:e<u)?s=o/e:o=s*e,{width:o,height:s,x:(n-o)/2,y:(t-s)/2}}}var t=n(!0),r=n(!1);i.contain=t,i.cover=r}(this.intrinsicScale=this.intrinsicScale||{});

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 function fit(contains) {
 	return (parentWidth, parentHeight, childWidth, childHeight) => {
-		const doRatio = childWidth / childHeight;
+		const doRatio = typeof childHeight === 'number' ?
+			childWidth / childHeight :
+			childWidth;
 		const cRatio = parentWidth / parentHeight;
 		let width = parentWidth;
 		let height = parentHeight;

--- a/index.test.js
+++ b/index.test.js
@@ -6,196 +6,322 @@ const PORTRAIT = {height: 200, width: 100};
 
 describe('contain', () => {
 	describe('works with square parents', () => {
-		test('and square children', () => {
+		describe('and square children', () => {
 			const result = {
 				width: 200,
 				height: 200,
 				x: 0,
 				y: 0
 			};
-			expect(contain(SQUARE.width, SQUARE.height, 50, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(SQUARE.width, SQUARE.height, 50, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(SQUARE.width, SQUARE.height, 1)).toEqual(result);
+			});
 		});
 
-		test('and landscape children', () => {
+		describe('and landscape children', () => {
 			const result = {
 				width: 200,
 				height: 100,
 				x: 0,
 				y: 50
 			};
-			expect(contain(SQUARE.width, SQUARE.height, 100, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(SQUARE.width, SQUARE.height, 100, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(SQUARE.width, SQUARE.height, 2)).toEqual(result);
+			});
 		});
 
-		test('and portrait children', () => {
+		describe('and portrait children', () => {
 			const result = {
 				width: 100,
 				height: 200,
 				x: 50,
 				y: 0
 			};
-			expect(contain(SQUARE.width, SQUARE.height, 50, 100)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(SQUARE.width, SQUARE.height, 50, 100)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(SQUARE.width, SQUARE.height, 0.5)).toEqual(result);
+			});
 		});
 	});
 
 	describe('works with landscape parents', () => {
-		test('and square children', () => {
+		describe('and square children', () => {
 			const result = {
 				width: 100,
 				height: 100,
 				x: 50,
 				y: 0
 			};
-			expect(contain(LANDSCAPE.width, LANDSCAPE.height, 50, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(LANDSCAPE.width, LANDSCAPE.height, 50, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(LANDSCAPE.width, LANDSCAPE.height, 1)).toEqual(result);
+			});
 		});
 
-		test('and landscape children', () => {
+		describe('and landscape children', () => {
 			const result = {
 				width: 200,
 				height: 100,
 				x: 0,
 				y: 0
 			};
-			expect(contain(LANDSCAPE.width, LANDSCAPE.height, 100, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(LANDSCAPE.width, LANDSCAPE.height, 100, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(LANDSCAPE.width, LANDSCAPE.height, 2)).toEqual(result);
+			});
 		});
 
-		test('and portrait children', () => {
+		describe('and portrait children', () => {
 			const result = {
 				width: 50,
 				height: 100,
 				x: 75,
 				y: 0
 			};
-			expect(contain(LANDSCAPE.width, LANDSCAPE.height, 50, 100)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(LANDSCAPE.width, LANDSCAPE.height, 50, 100)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(LANDSCAPE.width, LANDSCAPE.height, 0.5)).toEqual(result);
+			});
 		});
 	});
 
 	describe('works with portrait parents', () => {
-		test('and square children', () => {
+		describe('and square children', () => {
 			const result = {
 				width: 100,
 				height: 100,
 				x: 0,
 				y: 50
 			};
-			expect(contain(PORTRAIT.width, PORTRAIT.height, 50, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(PORTRAIT.width, PORTRAIT.height, 50, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(PORTRAIT.width, PORTRAIT.height, 1)).toEqual(result);
+			});
 		});
 
-		test('and landscape children', () => {
+		describe('and landscape children', () => {
 			const result = {
 				width: 100,
 				height: 50,
 				x: 0,
 				y: 75
 			};
-			expect(contain(PORTRAIT.width, PORTRAIT.height, 100, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(PORTRAIT.width, PORTRAIT.height, 100, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(PORTRAIT.width, PORTRAIT.height, 2)).toEqual(result);
+			});
 		});
 
-		test('and portrait children', () => {
+		describe('and portrait children', () => {
 			const result = {
 				width: 100,
 				height: 200,
 				x: 0,
 				y: 0
 			};
-			expect(contain(PORTRAIT.width, PORTRAIT.height, 50, 100)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(contain(PORTRAIT.width, PORTRAIT.height, 50, 100)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(contain(PORTRAIT.width, PORTRAIT.height, 0.5)).toEqual(result);
+			});
 		});
 	});
 });
 
 describe('cover', () => {
 	describe('works with square parents', () => {
-		test('and square children', () => {
+		describe('and square children', () => {
 			const result = {
 				width: 200,
 				height: 200,
 				x: 0,
 				y: 0
 			};
-			expect(cover(SQUARE.width, SQUARE.height, 50, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(SQUARE.width, SQUARE.height, 50, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(SQUARE.width, SQUARE.height, 1)).toEqual(result);
+			});
 		});
 
-		test('and landscape children', () => {
+		describe('and landscape children', () => {
 			const result = {
 				width: 400,
 				height: 200,
 				x: -100,
 				y: 0
 			};
-			expect(cover(SQUARE.width, SQUARE.height, 100, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(SQUARE.width, SQUARE.height, 100, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(SQUARE.width, SQUARE.height, 2)).toEqual(result);
+			});
 		});
 
-		test('and portrait children', () => {
+		describe('and portrait children', () => {
 			const result = {
 				width: 200,
 				height: 400,
 				x: 0,
 				y: -100
 			};
-			expect(cover(SQUARE.width, SQUARE.height, 50, 100)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(SQUARE.width, SQUARE.height, 50, 100)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(SQUARE.width, SQUARE.height, 0.5)).toEqual(result);
+			});
 		});
 	});
 
 	describe('works with landscape parents', () => {
-		test('and square children', () => {
+		describe('and square children', () => {
 			const result = {
 				width: 200,
 				height: 200,
 				x: 0,
 				y: -50
 			};
-			expect(cover(LANDSCAPE.width, LANDSCAPE.height, 50, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(LANDSCAPE.width, LANDSCAPE.height, 50, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(LANDSCAPE.width, LANDSCAPE.height, 1)).toEqual(result);
+			});
 		});
 
-		test('and landscape children', () => {
+		describe('and landscape children', () => {
 			const result = {
 				width: 200,
 				height: 100,
 				x: 0,
 				y: 0
 			};
-			expect(cover(LANDSCAPE.width, LANDSCAPE.height, 100, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(LANDSCAPE.width, LANDSCAPE.height, 100, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(LANDSCAPE.width, LANDSCAPE.height, 2)).toEqual(result);
+			});
 		});
 
-		test('and portrait children', () => {
+		describe('and portrait children', () => {
 			const result = {
 				width: 200,
 				height: 400,
 				x: 0,
 				y: -150
 			};
-			expect(cover(LANDSCAPE.width, LANDSCAPE.height, 50, 100)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(LANDSCAPE.width, LANDSCAPE.height, 50, 100)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(LANDSCAPE.width, LANDSCAPE.height, 0.5)).toEqual(result);
+			});
 		});
 	});
 
 	describe('works with portrait parents', () => {
-		test('and square children', () => {
+		describe('and square children', () => {
 			const result = {
 				width: 200,
 				height: 200,
 				x: -50,
 				y: 0
 			};
-			expect(cover(PORTRAIT.width, PORTRAIT.height, 50, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(PORTRAIT.width, PORTRAIT.height, 50, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(PORTRAIT.width, PORTRAIT.height, 1)).toEqual(result);
+			});
 		});
 
-		test('and landscape children', () => {
+		describe('and landscape children', () => {
 			const result = {
 				width: 400,
 				height: 200,
 				x: -150,
 				y: 0
 			};
-			expect(cover(PORTRAIT.width, PORTRAIT.height, 100, 50)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(PORTRAIT.width, PORTRAIT.height, 100, 50)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(PORTRAIT.width, PORTRAIT.height, 2)).toEqual(result);
+			});
 		});
 
-		test('and portrait children', () => {
+		describe('and portrait children', () => {
 			const result = {
 				width: 100,
 				height: 200,
 				x: 0,
 				y: 0
 			};
-			expect(cover(PORTRAIT.width, PORTRAIT.height, 50, 100)).toEqual(result);
+
+			test('when passing width and height', () => {
+				expect(cover(PORTRAIT.width, PORTRAIT.height, 50, 100)).toEqual(result);
+			});
+
+			test('when passing a ratio', () => {
+				expect(cover(PORTRAIT.width, PORTRAIT.height, 0.5)).toEqual(result);
+			});
 		});
 	});
 });

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,201 @@
+const {contain, cover} = require('./index');
+
+const SQUARE = {height: 200, width: 200};
+const LANDSCAPE = {height: 100, width: 200};
+const PORTRAIT = {height: 200, width: 100};
+
+describe('contain', () => {
+	describe('works with square parents', () => {
+		test('and square children', () => {
+			const result = {
+				width: 200,
+				height: 200,
+				x: 0,
+				y: 0
+			};
+			expect(contain(SQUARE.width, SQUARE.height, 50, 50)).toEqual(result);
+		});
+
+		test('and landscape children', () => {
+			const result = {
+				width: 200,
+				height: 100,
+				x: 0,
+				y: 50
+			};
+			expect(contain(SQUARE.width, SQUARE.height, 100, 50)).toEqual(result);
+		});
+
+		test('and portrait children', () => {
+			const result = {
+				width: 100,
+				height: 200,
+				x: 50,
+				y: 0
+			};
+			expect(contain(SQUARE.width, SQUARE.height, 50, 100)).toEqual(result);
+		});
+	});
+
+	describe('works with landscape parents', () => {
+		test('and square children', () => {
+			const result = {
+				width: 100,
+				height: 100,
+				x: 50,
+				y: 0
+			};
+			expect(contain(LANDSCAPE.width, LANDSCAPE.height, 50, 50)).toEqual(result);
+		});
+
+		test('and landscape children', () => {
+			const result = {
+				width: 200,
+				height: 100,
+				x: 0,
+				y: 0
+			};
+			expect(contain(LANDSCAPE.width, LANDSCAPE.height, 100, 50)).toEqual(result);
+		});
+
+		test('and portrait children', () => {
+			const result = {
+				width: 50,
+				height: 100,
+				x: 75,
+				y: 0
+			};
+			expect(contain(LANDSCAPE.width, LANDSCAPE.height, 50, 100)).toEqual(result);
+		});
+	});
+
+	describe('works with portrait parents', () => {
+		test('and square children', () => {
+			const result = {
+				width: 100,
+				height: 100,
+				x: 0,
+				y: 50
+			};
+			expect(contain(PORTRAIT.width, PORTRAIT.height, 50, 50)).toEqual(result);
+		});
+
+		test('and landscape children', () => {
+			const result = {
+				width: 100,
+				height: 50,
+				x: 0,
+				y: 75
+			};
+			expect(contain(PORTRAIT.width, PORTRAIT.height, 100, 50)).toEqual(result);
+		});
+
+		test('and portrait children', () => {
+			const result = {
+				width: 100,
+				height: 200,
+				x: 0,
+				y: 0
+			};
+			expect(contain(PORTRAIT.width, PORTRAIT.height, 50, 100)).toEqual(result);
+		});
+	});
+});
+
+describe('cover', () => {
+	describe('works with square parents', () => {
+		test('and square children', () => {
+			const result = {
+				width: 200,
+				height: 200,
+				x: 0,
+				y: 0
+			};
+			expect(cover(SQUARE.width, SQUARE.height, 50, 50)).toEqual(result);
+		});
+
+		test('and landscape children', () => {
+			const result = {
+				width: 400,
+				height: 200,
+				x: -100,
+				y: 0
+			};
+			expect(cover(SQUARE.width, SQUARE.height, 100, 50)).toEqual(result);
+		});
+
+		test('and portrait children', () => {
+			const result = {
+				width: 200,
+				height: 400,
+				x: 0,
+				y: -100
+			};
+			expect(cover(SQUARE.width, SQUARE.height, 50, 100)).toEqual(result);
+		});
+	});
+
+	describe('works with landscape parents', () => {
+		test('and square children', () => {
+			const result = {
+				width: 200,
+				height: 200,
+				x: 0,
+				y: -50
+			};
+			expect(cover(LANDSCAPE.width, LANDSCAPE.height, 50, 50)).toEqual(result);
+		});
+
+		test('and landscape children', () => {
+			const result = {
+				width: 200,
+				height: 100,
+				x: 0,
+				y: 0
+			};
+			expect(cover(LANDSCAPE.width, LANDSCAPE.height, 100, 50)).toEqual(result);
+		});
+
+		test('and portrait children', () => {
+			const result = {
+				width: 200,
+				height: 400,
+				x: 0,
+				y: -150
+			};
+			expect(cover(LANDSCAPE.width, LANDSCAPE.height, 50, 100)).toEqual(result);
+		});
+	});
+
+	describe('works with portrait parents', () => {
+		test('and square children', () => {
+			const result = {
+				width: 200,
+				height: 200,
+				x: -50,
+				y: 0
+			};
+			expect(cover(PORTRAIT.width, PORTRAIT.height, 50, 50)).toEqual(result);
+		});
+
+		test('and landscape children', () => {
+			const result = {
+				width: 400,
+				height: 200,
+				x: -150,
+				y: 0
+			};
+			expect(cover(PORTRAIT.width, PORTRAIT.height, 100, 50)).toEqual(result);
+		});
+
+		test('and portrait children', () => {
+			const result = {
+				width: 100,
+				height: 200,
+				x: 0,
+				y: 0
+			};
+			expect(cover(PORTRAIT.width, PORTRAIT.height, 50, 100)).toEqual(result);
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -34,12 +34,17 @@
     "watch:build": "onchange 'index.js' --initial -- npm run build -- --continue-on-error",
     "watch": "npm-run-all --parallel --silent watch:*",
     "prepublish": "npm run build",
-    "test": "xo; npm run build"
+    "test": "xo && jest; npm run build"
   },
   "devDependencies": {
+    "@babel/core": "^7.2.2",
+    "@babel/preset-env": "^7.2.3",
+    "babel-core": "^7.0.0-bridge.0",
     "bfred-npm-bundler": "^7.1.2",
+    "jest": "^23.6.0",
     "npm-run-all": "^2.3.0",
     "onchange": "^2.5.0",
+    "regenerator-runtime": "^0.13.1",
     "xo": "^0.16.0"
   },
   "xo": {
@@ -49,6 +54,12 @@
     ],
     "rules": {
       "prefer-spread": 0
-    }
+    },
+    "overrides": [{
+      "files": "*.test.js",
+      "rules": {
+        "no-undef": "off"
+      }
+    }]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 [![gzipped size](https://badges.herokuapp.com/size/github/bfred-it/intrinsic-scale/master/dist/intrinsic-scale.browser.js?gzip=true&label=gzipped%20size)](#readme)
 [![Travis build status](https://api.travis-ci.org/bfred-it/intrinsic-scale.svg?branch=master)](https://travis-ci.org/bfred-it/intrinsic-scale)
-[![gzipped size](https://img.shields.io/npm/v/intrinsic-scale.svg)](https://www.npmjs.com/package/intrinsic-scale) 
+[![gzipped size](https://img.shields.io/npm/v/intrinsic-scale.svg)](https://www.npmjs.com/package/intrinsic-scale)
 
 Given a *original* height and width, and a *desired* height and width, get the `width`, `height`, and `scale` that the *original* object should have to fit the *desired* object.
 
@@ -34,6 +34,14 @@ let { width, height, x, y } = contain(100, 200, 50, 50);
 console.log(width, height, x, y);
 //100 100 0 50
 
+/*
+Given an element with an aspect ratio of 1 in a 100px 200px parent
+To be contains in its parent it must be of size 100px 100px
+and be positioned at 0px 50px to be centered.
+*/
+let { width, height, x, y } = contain(100, 200, 1);
+console.log(width, height, x, y);
+//100 100 0 50
 
 /*
 Given an 50px 50px element in a 100px 200px parent
@@ -41,6 +49,15 @@ To be covered in its parent it must be of size 200px 200px
 and be positioned at -50px 0px to be centered.
 */
 let { width, height, x, y } = cover(100, 200, 50, 50);
+console.log(width, height, x, y);
+//200 200 -50 0
+
+/*
+Given an element with an aspect ratio of 1 in a 100px 200px parent
+To be covered in its parent it must be of size 200px 200px
+and be positioned at -50px 0px to be centered.
+*/
+let { width, height, x, y } = cover(100, 200, 1);
 console.log(width, height, x, y);
 //200 200 -50 0
 ```


### PR DESCRIPTION
This is allowing users to overload both `contain` and `cover` functions by passing a child ratio in cases where the exact child width and height might be unknown. This is backwards compatible with the previous function signatures.