### PR TITLE
Added "module" type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "funding": "https://github.com/sponsors/fregante",
   "license": "MIT",
   "author": "Federico Brigante <me@fregante.com> (https://fregante.com)",
+  "type": "module",
   "exports": "./index.js",
   "files": [
     "index.js",


### PR DESCRIPTION
Added type "module" to package.json to resolve `Unexpected token 'export'` error when using Vite